### PR TITLE
 Enabled InsecureSkipVerify in tlsConfig

### DIFF
--- a/src/github.com/cloudfoundry-community/vps/api/configure_soft_layer_vm_pool.go
+++ b/src/github.com/cloudfoundry-community/vps/api/configure_soft_layer_vm_pool.go
@@ -62,6 +62,7 @@ db db.DB,
 // The TLS configuration before HTTPS server starts.
 func configureTLS(tlsConfig *tls.Config) {
 	// Make all necessary changes to the TLS configuration here.
+	tlsConfig.InsecureSkipVerify = true
 }
 
 // The middleware configuration is for the handler executors. These do not apply to the swagger.json document.


### PR DESCRIPTION
Since we did not have official signed certificate, just enable InsecureSkipVerify only for testing purpose, will disable it in future.